### PR TITLE
Added Tensorboard Logger

### DIFF
--- a/tf_lightning/utilities/loggers.py
+++ b/tf_lightning/utilities/loggers.py
@@ -3,7 +3,11 @@
 @author: vasudevgupta
 """
 import wandb
-
+import os
+import tensorflow as tf
+import numpy as np
+from matplotlib.figure import Figure
+import io
 
 class WandbLogger(object):
 
@@ -22,3 +26,53 @@ class WandbLogger(object):
 
     def log(self, info, commit=True, step=None):
         wandb.log(info, commit=commit, step=step)
+
+class TBSummary(object):
+    def __init__(self, logdir, expt_name=""):
+        log_path = os.path.join(logdir, expt_name)
+        self.writer = tf.summary.create_file_writer(log_path)
+
+    def log(self, **kwargs):
+        step = kwargs.pop('step', None)
+        for name, value in kwargs.items():
+            if hasattr(value, '__len__') and not isinstance(value, np.ndarray):
+                self._add_multiple(name, value, step)
+            else:
+                self._add_single(name, value, step)
+    
+    def add_scalar(self, name, value, step=None):
+        with self.writer.as_default():
+            tf.summary.scalar(name=name, data=value, step=step)
+            self.writer.flush()
+
+    def plot_to_image(self, figure):
+        buf = io.BytesIO()
+        plt.savefig(buf, format='png')
+        plt.close(figure)
+        buf.seek(0)
+        image = tf.image.decode_png(buf.getvalue(), channels=4)
+        image = tf.expand_dims(image, 0)
+        return image
+
+    def add_image(self, name, image, step=None):
+        if isinstance(image, Figure):
+            image = self.plot_to_image(image)
+        elif isinstance(image, np.ndarray):
+            image = image
+        else:
+            raise ValueError("Incorrect Image type. Type must be numpy array or matplotlib figure")
+        with self.writer.as_default():
+            tf.summary.image(name, image, step=step)
+            self.writer.flush()
+
+    def _add_single(self, name, value, step=None):
+        if np.isscalar(value):
+            self.add_scalar(name, value, step)
+        elif isinstance(value, np.ndarray) or isinstance(value, Figure):
+            self.add_image(name, value, step)
+        else:
+            raise ValueError("Incorrect type. Allowable datatypes are scalars, numpy ndarray, matplotlib figures")
+
+    def _add_multiple(self, name, values, step=None):
+        for i, value in enumerate(values):
+            self._add_single('%s/%d' % (name, i), value, step)

--- a/tf_lightning/utilities/loggers.py
+++ b/tf_lightning/utilities/loggers.py
@@ -28,6 +28,19 @@ class WandbLogger(object):
         wandb.log(info, commit=commit, step=step)
 
 class TBSummary(object):
+    """
+    Parameters:
+        logdir: string
+            Directory where all of the events will be written out.
+        expt_name: string
+            Optional; name for a particular summary, ex. training.
+    Attributes:
+        writer: tf.summary.FileWriter
+            The writer that write `tf_summary` into a tensorflow event file.
+    Methods:
+        log: step=<step number>, metric_name1=<metric_value>, metric_name2=<metric_value>, ......
+             metric value can be a scalar, numpy array (image), matplotlib figure object or a iterable object containing multiple values.
+    """
     def __init__(self, logdir, expt_name=""):
         log_path = os.path.join(logdir, expt_name)
         self.writer = tf.summary.create_file_writer(log_path)
@@ -40,12 +53,12 @@ class TBSummary(object):
             else:
                 self._add_single(name, value, step)
     
-    def add_scalar(self, name, value, step=None):
+    def _add_scalar(self, name, value, step=None):
         with self.writer.as_default():
             tf.summary.scalar(name=name, data=value, step=step)
             self.writer.flush()
 
-    def plot_to_image(self, figure):
+    def _plot_to_image(self, figure):
         buf = io.BytesIO()
         plt.savefig(buf, format='png')
         plt.close(figure)
@@ -54,9 +67,9 @@ class TBSummary(object):
         image = tf.expand_dims(image, 0)
         return image
 
-    def add_image(self, name, image, step=None):
+    def _add_image(self, name, image, step=None):
         if isinstance(image, Figure):
-            image = self.plot_to_image(image)
+            image = self._plot_to_image(image)
         elif isinstance(image, np.ndarray):
             image = image
         else:
@@ -67,9 +80,9 @@ class TBSummary(object):
 
     def _add_single(self, name, value, step=None):
         if np.isscalar(value):
-            self.add_scalar(name, value, step)
+            self._add_scalar(name, value, step)
         elif isinstance(value, np.ndarray) or isinstance(value, Figure):
-            self.add_image(name, value, step)
+            self._add_image(name, value, step)
         else:
             raise ValueError("Incorrect type. Allowable datatypes are scalars, numpy ndarray, matplotlib figures")
 


### PR DESCRIPTION
Added tensorboard logger with the following features:
- log scalars
- log images as numpy ndarrays / matplotlib figures
- log many values under the same name / multiple values at once

```python
# Example:
writer = TBSummary(logdir, expt_name)
i = 0
while True:

    # log single scalar
    writer.log(step=i, loss=random.random(100))

    # log different metrics at once
    writer.log(step=i, loss=random.random(100), accuracy=random.randint(0,100))

    # log list of metrics (possible use case multiple loss values contained in a single list)
    writer.log(step=i, loss=[random.random(100) for j in range(10)])

    # log images (numpy arrays)
    writer.log(step=i, mnist_data=np.random.randn(1,100, 100, 1))  # shape - (num_images, height, width, channels)

    # log plots (matplotlib figures)
    fig = plt.figure()
    plt.plot(np.arange(100), np.random.random(100))
    writer.log(step=i, loss_plot = fig)   
```

In essence the usage is 
```python
writer.log(step=<step number>, metric_name1=<metric_value>, metric_name2=<metric_value>, ......)
# metric value can be a scalar, numpy array (image), matplotlib figure object or a iterable object containing multiple values.
```

**PS: if you plan on merging this you would have to change the wandb class with similar `**kwargs option` to ensure common writer methods**